### PR TITLE
Add support for proc to value validators

### DIFF
--- a/lib/grape/extra_validators/maximum_value.rb
+++ b/lib/grape/extra_validators/maximum_value.rb
@@ -14,10 +14,13 @@ module Grape
       def validate_param!(attr_name, params)
         return if !@required && params[attr_name].blank?
 
-        value = params[attr_name].to_i
-        return if value <= @option
+        maximum_value = @option.instance_of?(Proc) ? @option.call(params) : @option
+        return if maximum_value.blank?
 
-        message = "must be equal to or below #{@option}"
+        value = params[attr_name].to_i
+        return if value <= maximum_value
+
+        message = "must be equal to or below #{maximum_value}"
 
         fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
       end

--- a/lib/grape/extra_validators/minimum_value.rb
+++ b/lib/grape/extra_validators/minimum_value.rb
@@ -14,10 +14,13 @@ module Grape
       def validate_param!(attr_name, params)
         return if !@required && params[attr_name].blank?
 
-        value = params[attr_name].to_i
-        return if value >= @option
+        minimum_value = @option.instance_of?(Proc) ? @option.call(params) : @option
+        return if minimum_value.blank?
 
-        message = "must be equal to or above #{@option}"
+        value = params[attr_name].to_i
+        return if value >= minimum_value
+
+        message = "must be equal to or above #{minimum_value}"
 
         fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
       end

--- a/spec/grape/extra_validators/maximum_value_spec.rb
+++ b/spec/grape/extra_validators/maximum_value_spec.rb
@@ -7,7 +7,9 @@ describe Grape::ExtraValidators::MaximumValue do
         default_format :json
 
         params do
-          optional :number, type: Integer, maximum_value: 10
+          optional :static_number, type: Integer, maximum_value: 10
+          optional :maximum_value_for_proc_number, type: Integer, allow_blank: false
+          optional :proc_number, type: Integer, maximum_value: ->(params) { params[:maximum_value_for_proc_number] + 1 }
         end
         post "/" do
           body false
@@ -20,30 +22,65 @@ describe Grape::ExtraValidators::MaximumValue do
     ValidationsSpec::MaximumValueValidatorSpec::API
   end
 
-  let(:params) { { number: number } }
-  let(:number) { nil }
+  let(:params) do
+    {
+      static_number: static_number,
+      maximum_value_for_proc_number: maximum_value_for_proc_number,
+      proc_number: proc_number,
+    }.compact
+  end
+  let(:static_number) { nil }
+  let(:maximum_value_for_proc_number) { nil }
+  let(:proc_number) { nil }
   before { post "/", params }
   subject { last_response.status }
 
-  context "when the value is less than the configured minimum value" do
-    let(:number) { 9 }
+  context "when a configured maximum value is a static value" do
+    context "the value is less than the maximum value" do
+      let(:static_number) { 9 }
 
-    it { is_expected.to eq(204) }
+      it { is_expected.to eq(204) }
+    end
+
+    context "the value is equal to the maximum value" do
+      let(:static_number) { 10 }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "the value is more than the maximum value" do
+      let(:static_number) { 11 }
+
+      it { is_expected.to eq(400) }
+    end
   end
 
-  context "when the value is equal to the configured minimum value" do
-    let(:number) { 10 }
+  context "when a configured maximum value is a Proc" do
+    context "the value is less than the maximum value" do
+      let(:maximum_value_for_proc_number) { 10 }
+      let(:proc_number) { 10 }
 
-    it { is_expected.to eq(204) }
-  end
+      it { is_expected.to eq(204) }
+    end
 
-  context "when the value is more than the configured minimum value" do
-    let(:number) { 11 }
+    context "the value is equal to the maximum value" do
+      let(:maximum_value_for_proc_number) { 10 }
+      let(:proc_number) { 11 }
 
-    it { is_expected.to eq(400) }
+      it { is_expected.to eq(204) }
+    end
+
+    context "the value is more than the maximum value" do
+      let(:maximum_value_for_proc_number) { 10 }
+      let(:proc_number) { 12 }
+
+      it { is_expected.to eq(400) }
+    end
   end
 
   context "when the parameter is nil" do
+    let(:params) { {} }
+
     it { is_expected.to eq(204) }
   end
 end


### PR DESCRIPTION
# New Features
- Add support for giving Proc object to `maximum_value`
- Add support for giving Proc object to `minimum_value`
