### PR TITLE
Array params support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ end
     - [Minimum Length](#minimum-length)
     - [Start With](#start-with)
     - [End With](#end-with)
+  - [For Array](#for-array)
+    - [Length](#length-1)
+    - [Maximum Length](#maximum-length-1)
+    - [Minimum Length](#minimum-length-1)
   - [For Numeric](#for-numeric)
     - [Value](#value)
     - [Maximum Value](#maximum-value)
@@ -112,6 +116,38 @@ or Array which has strings object to this.
 params do
   requires :price, type: String, end_with: "JPY"
   requires :price, type: String, end_with: %w(JPY USD)
+end
+```
+
+### For Array
+#### Length
+The length validator checks whether the parameter contains a specified number of items or number of items is within a specified
+range. You can specify an Integer or Range object to this.
+
+```rb
+params do
+  requires :values, type: Array, length: 4
+  requires :other_values, type: Array, length: 4..10
+end
+```
+
+#### Maximum Length
+The maximum length validator checks whether the parameter contains up to a specified number of items. You can specify an Integer
+object to this.
+
+```rb
+params do
+  requires :values, type: Array, maximum_length: 5
+end
+```
+
+#### Minimum Length
+The minimum length validator checks whether the parameter contains at least a specified number of items. You can specify an Integer
+object to this.
+
+```rb
+params do
+  requires :values, type: Array, minimum_length: 3
 end
 ```
 

--- a/lib/grape/extra_validators/length.rb
+++ b/lib/grape/extra_validators/length.rb
@@ -12,20 +12,35 @@ module Grape
       # Public Methods
       # ------------------------------------------------------------------------------------------------------------------------
       def validate_param!(attr_name, params)
-        return if !@required && params[attr_name].blank?
+        value = params[attr_name]
+        return if !@required && value.blank?
 
-        if @option.instance_of?(Range)
-          return if @option.include?(params[attr_name].length)
-
-          message = "must be #{@option.first} to #{@option.last} characters long"
-          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
+        unless [String, Array].include? value.class
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "length cannot be validated (wrong parameter type: #{value.class})")
         end
 
-        return if params[attr_name].length == @option
+        # If option is a range we check if value length included in the range
+        if @option.instance_of?(Range)
+          return if @option.include?(value.length)
 
-        unit = "character".pluralize(@option)
-        message = "must be #{@option} #{unit} long"
-        fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
+          if value.is_a? String
+            message = "must be #{@option.first} to #{@option.last} characters long"
+          else # Array
+            message = "must have #{@option.first} to #{@option.last} items"
+          end
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
+        else
+          # If option is a single value we check if length matches it
+          return if value.length == @option
+          if value.is_a? String
+            unit = "character".pluralize(@option)
+            message = "must be #{@option} #{unit} long"
+          else # Array
+            unit = "item".pluralize(@option)
+            message = "must have exactly #{@option} #{unit}"
+          end
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
+        end
       end
     end
   end

--- a/lib/grape/extra_validators/maximum_length.rb
+++ b/lib/grape/extra_validators/maximum_length.rb
@@ -12,12 +12,22 @@ module Grape
       # Public Methods
       # ------------------------------------------------------------------------------------------------------------------------
       def validate_param!(attr_name, params)
-        return if !@required && params[attr_name].blank?
-        return if params[attr_name].length <= @option
+        value = params[attr_name]
+        return if !@required && value.blank?
 
-        unit = "character".pluralize(@option)
-        message = "must be up to #{@option} #{unit} long"
+        unless [String, Array].include? value.class
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "maximum length cannot be validated (wrong parameter type: #{value.class})")
+        end
 
+        return if value.length <= @option
+
+        if value.is_a? String
+          unit = "character".pluralize(@option)
+          message = "must be up to #{@option} #{unit} long"
+        else # Array
+          unit = "item".pluralize(@option)
+          message = "must have up to #{@option} #{unit}"
+        end
         fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
       end
     end

--- a/lib/grape/extra_validators/maximum_length.rb
+++ b/lib/grape/extra_validators/maximum_length.rb
@@ -16,7 +16,8 @@ module Grape
         return if !@required && value.blank?
 
         unless [String, Array].include? value.class
-          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "maximum length cannot be validated (wrong parameter type: #{value.class})")
+          message = "maximum length cannot be validated (wrong parameter type: #{value.class})"
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
         end
 
         return if value.length <= @option

--- a/lib/grape/extra_validators/minimum_length.rb
+++ b/lib/grape/extra_validators/minimum_length.rb
@@ -16,7 +16,8 @@ module Grape
         return if !@required && value.blank?
 
         unless [String, Array].include? value.class
-          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "minimum length cannot be validated (wrong parameter type: #{value.class})")
+          message = "minimum length cannot be validated (wrong parameter type: #{value.class})"
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
         end
 
         return if value.length >= @option

--- a/lib/grape/extra_validators/minimum_length.rb
+++ b/lib/grape/extra_validators/minimum_length.rb
@@ -12,11 +12,22 @@ module Grape
       # Public Methods
       # ------------------------------------------------------------------------------------------------------------------------
       def validate_param!(attr_name, params)
-        return if !@required && params[attr_name].blank?
-        return if params[attr_name].length >= @option
+        value = params[attr_name]
+        return if !@required && value.blank?
 
-        unit = "character".pluralize(@option)
-        message = "must be at least #{@option} #{unit} long"
+        unless [String, Array].include? value.class
+          fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: "minimum length cannot be validated (wrong parameter type: #{value.class})")
+        end
+
+        return if value.length >= @option
+
+        if value.is_a? String
+          unit = "character".pluralize(@option)
+          message = "must be at least #{@option} #{unit} long"
+        else # Array
+          unit = "item".pluralize(@option)
+          message = "must have at least #{@option} #{unit}"
+        end
 
         fail Grape::Exceptions::Validation.new(params: [@scope.full_name(attr_name)], message: message)
       end

--- a/lib/grape/extra_validators/version.rb
+++ b/lib/grape/extra_validators/version.rb
@@ -2,6 +2,6 @@
 
 module Grape
   module ExtraValidators
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/spec/grape/extra_validators/length_spec.rb
+++ b/spec/grape/extra_validators/length_spec.rb
@@ -126,9 +126,10 @@ describe Grape::ExtraValidators::Length do
 
       context "when the length is less than the configured length" do
         let(:values) { [1, 2] }
-        it 'fails with corresponding message' do
+        it "fails with corresponding message" do
           is_expected.to eq(400)
-          expect(JSON.parse(last_response.body)["error"]).to eq("values must have exactly 3 items")
+          error = JSON.parse(last_response.body)["error"]
+          expect(error).to eq("values must have exactly 3 items")
         end
       end
 
@@ -139,9 +140,10 @@ describe Grape::ExtraValidators::Length do
 
       context "when the length is more than the configured length" do
         let(:values) { [1, 2, 3, 4] }
-        it 'fails with corresponding message' do
+        it "fails with corresponding message" do
           is_expected.to eq(400)
-          expect(JSON.parse(last_response.body)["error"]).to eq("values must have exactly 3 items")
+          error = JSON.parse(last_response.body)["error"]
+          expect(error).to eq("values must have exactly 3 items")
         end
       end
 
@@ -155,9 +157,10 @@ describe Grape::ExtraValidators::Length do
 
       context "when the length is less than the configured minimum length" do
         let(:values) { [1] }
-        it 'fails with corresponding message' do
+        it "fails with corresponding message" do
           is_expected.to eq(400)
-          expect(JSON.parse(last_response.body)["error"]).to eq("values must have 2 to 4 items")
+          error = JSON.parse(last_response.body)["error"]
+          expect(error).to eq("values must have 2 to 4 items")
         end
       end
 
@@ -176,9 +179,10 @@ describe Grape::ExtraValidators::Length do
 
       context "when the length is more than the configured maximum length" do
         let(:values) { [1, 2, 3, 4, 5] }
-        it 'fails with corresponding message' do
+        it "fails with corresponding message" do
           is_expected.to eq(400)
-          expect(JSON.parse(last_response.body)["error"]).to eq("values must have 2 to 4 items")
+          error = JSON.parse(last_response.body)["error"]
+          expect(error).to eq("values must have 2 to 4 items")
         end
       end
 

--- a/spec/grape/extra_validators/length_spec.rb
+++ b/spec/grape/extra_validators/length_spec.rb
@@ -6,18 +6,36 @@ describe Grape::ExtraValidators::Length do
       class API < Grape::API
         default_format :json
 
-        params do
-          optional :text, type: String, length: 6
-        end
-        post "/integer" do
-          body false
+        resource :text do
+          params do
+            optional :text, type: String, length: 6
+          end
+          post "/integer" do
+            body false
+          end
+
+          params do
+            optional :text, type: String, length: 4..8
+          end
+          post "/range" do
+            body false
+          end
         end
 
-        params do
-          optional :text, type: String, length: 4..8
-        end
-        post "/range" do
-          body false
+        resource :array do
+          params do
+            optional :values, type: Array[Integer], length: 3
+          end
+          post "/integer" do
+            body false
+          end
+
+          params do
+            optional :values, type: Array[Integer], length: 2..4
+          end
+          post "/range" do
+            body false
+          end
         end
       end
     end
@@ -27,72 +45,146 @@ describe Grape::ExtraValidators::Length do
     ValidationsSpec::LengthValidatorSpec::API
   end
 
-  let(:params) { { text: text } }
-  let(:text) { nil }
-  subject { last_response.status }
+  describe "String value validation" do
+    let(:params) { { text: text } }
+    let(:text) { nil }
+    subject { last_response.status }
 
-  describe "Specify an integer number" do
-    before { post "/integer", params }
+    describe "Specify an integer number" do
+      before { post "/text/integer", params }
 
-    context "when the length is less than the configured length" do
-      let(:text) { "12345" }
+      context "when the length is less than the configured length" do
+        let(:text) { "12345" }
 
-      it { is_expected.to eq(400) }
-    end
+        it { is_expected.to eq(400) }
+      end
 
-    context "when the length is equal to the configured length" do
-      let(:text) { "123456" }
+      context "when the length is equal to the configured length" do
+        let(:text) { "123456" }
 
-      it { is_expected.to eq(204) }
-    end
+        it { is_expected.to eq(204) }
+      end
 
-    context "when the length is more than the configured length" do
-      let(:text) { "1234567" }
+      context "when the length is more than the configured length" do
+        let(:text) { "1234567" }
 
-      it { is_expected.to eq(400) }
-    end
+        it { is_expected.to eq(400) }
+      end
 
-    context "when the parameter is nil" do
-      it { is_expected.to eq(204) }
-    end
-  end
-
-  describe "Specify a range" do
-    before { |example| post "/range", params unless example.metadata[:skip_before_request_call] }
-
-    context "when the length is less than the configured minimum length" do
-      let(:text) { "123" }
-
-      it { is_expected.to eq(400) }
-    end
-
-    context "when the length is within the configured length", skip_before_request_call: true do
-      it "should pass" do
-        post "/range", { text: "1234" }
-        expect(last_response.status).to eq(204)
-
-        post "/range", { text: "12345" }
-        expect(last_response.status).to eq(204)
-
-        post "/range", { text: "123456" }
-        expect(last_response.status).to eq(204)
-
-        post "/range", { text: "1234567" }
-        expect(last_response.status).to eq(204)
-
-        post "/range", { text: "12345678" }
-        expect(last_response.status).to eq(204)
+      context "when the parameter is nil" do
+        it { is_expected.to eq(204) }
       end
     end
 
-    context "when the length is more than the configured maximum length" do
-      let(:text) { "123456789" }
+    describe "Specify a range" do
+      before { |example| post "/text/range", params unless example.metadata[:skip_before_request_call] }
 
-      it { is_expected.to eq(400) }
+      context "when the length is less than the configured minimum length" do
+        let(:text) { "123" }
+
+        it { is_expected.to eq(400) }
+      end
+
+      context "when the length is within the configured length", skip_before_request_call: true do
+        it "should pass" do
+          post "/text/range", { text: "1234" }
+          expect(last_response.status).to eq(204)
+
+          post "/text/range", { text: "12345" }
+          expect(last_response.status).to eq(204)
+
+          post "/text/range", { text: "123456" }
+          expect(last_response.status).to eq(204)
+
+          post "/text/range", { text: "1234567" }
+          expect(last_response.status).to eq(204)
+
+          post "/text/range", { text: "12345678" }
+          expect(last_response.status).to eq(204)
+        end
+      end
+
+      context "when the length is more than the configured maximum length" do
+        let(:text) { "123456789" }
+
+        it { is_expected.to eq(400) }
+      end
+
+      context "when the parameter is nil" do
+        it { is_expected.to eq(204) }
+      end
+    end
+  end
+
+  describe "Array value validation" do
+    let(:params) { { values: values } }
+    let(:values) { nil }
+    subject { last_response.status }
+
+    describe "Specify an integer number" do
+      before { post "/array/integer", params }
+
+      context "when the length is less than the configured length" do
+        let(:values) { [1, 2] }
+        it 'fails with corresponding message' do
+          is_expected.to eq(400)
+          expect(JSON.parse(last_response.body)["error"]).to eq("values must have exactly 3 items")
+        end
+      end
+
+      context "when the length is equal to the configured length" do
+        let(:values) { [1, 2, 3] }
+        it { is_expected.to eq(204) }
+      end
+
+      context "when the length is more than the configured length" do
+        let(:values) { [1, 2, 3, 4] }
+        it 'fails with corresponding message' do
+          is_expected.to eq(400)
+          expect(JSON.parse(last_response.body)["error"]).to eq("values must have exactly 3 items")
+        end
+      end
+
+      context "when the parameter is nil" do
+        it { is_expected.to eq(204) }
+      end
     end
 
-    context "when the parameter is nil" do
-      it { is_expected.to eq(204) }
+    describe "Specify a range" do
+      before { |example| post "/array/range", params unless example.metadata[:skip_before_request_call] }
+
+      context "when the length is less than the configured minimum length" do
+        let(:values) { [1] }
+        it 'fails with corresponding message' do
+          is_expected.to eq(400)
+          expect(JSON.parse(last_response.body)["error"]).to eq("values must have 2 to 4 items")
+        end
+      end
+
+      context "when the length is within the configured length", skip_before_request_call: true do
+        it "should pass" do
+          post "/array/range", { values: [1, 2] }
+          expect(last_response.status).to eq(204)
+
+          post "/array/range", { values: [1, 2, 3] }
+          expect(last_response.status).to eq(204)
+
+          post "/array/range", { values: [1, 2, 3, 4] }
+          expect(last_response.status).to eq(204)
+        end
+      end
+
+      context "when the length is more than the configured maximum length" do
+        let(:values) { [1, 2, 3, 4, 5] }
+        it 'fails with corresponding message' do
+          is_expected.to eq(400)
+          expect(JSON.parse(last_response.body)["error"]).to eq("values must have 2 to 4 items")
+        end
+      end
+
+      context "when the parameter is nil" do
+        it { is_expected.to eq(204) }
+      end
     end
   end
 end

--- a/spec/grape/extra_validators/maximum_length_spec.rb
+++ b/spec/grape/extra_validators/maximum_length_spec.rb
@@ -61,9 +61,10 @@ describe Grape::ExtraValidators::MaximumLength do
     context "when the length is more than the configured maximum length" do
       let(:text) { "123456789" }
 
-      it 'fails with corresponding message' do
+      it "fails with corresponding message" do
         is_expected.to eq(400)
-        expect(JSON.parse(last_response.body)["error"]).to eq("text must be up to 8 characters long")
+        error = JSON.parse(last_response.body)["error"]
+        expect(error).to eq("text must be up to 8 characters long")
       end
     end
 
@@ -93,9 +94,10 @@ describe Grape::ExtraValidators::MaximumLength do
     context "when the length is more than the configured maximum length" do
       let(:values) { [1, 2, 3, 4] }
 
-      it 'fails with corresponding message' do
+      it "fails with corresponding message" do
         is_expected.to eq(400)
-        expect(JSON.parse(last_response.body)["error"]).to eq("values must have up to 3 items")
+        error = JSON.parse(last_response.body)["error"]
+        expect(error).to eq("values must have up to 3 items")
       end
     end
 
@@ -110,7 +112,8 @@ describe Grape::ExtraValidators::MaximumLength do
     subject { last_response.status }
     it "fails with corresponding message" do
       is_expected.to eq(400)
-      expect(JSON.parse(last_response.body)["error"]).to eq("value maximum length cannot be validated (wrong parameter type: Integer)")
+      error = JSON.parse(last_response.body)["error"]
+      expect(error).to eq("value maximum length cannot be validated (wrong parameter type: Integer)")
     end
   end
 end

--- a/spec/grape/extra_validators/maximum_length_spec.rb
+++ b/spec/grape/extra_validators/maximum_length_spec.rb
@@ -6,11 +6,31 @@ describe Grape::ExtraValidators::MaximumLength do
       class API < Grape::API
         default_format :json
 
-        params do
-          optional :text, type: String, maximum_length: 8
+        resource :text do
+          params do
+            optional :text, type: String, maximum_length: 8
+          end
+          post do
+            body false
+          end
         end
-        post "/" do
-          body false
+
+        resource :array do
+          params do
+            optional :values, type: Array[Integer], maximum_length: 3
+          end
+          post do
+            body false
+          end
+        end
+
+        resource :integer do
+          params do
+            optional :value, type: Integer, maximum_length: 3
+          end
+          post do
+            body false
+          end
         end
       end
     end
@@ -20,30 +40,77 @@ describe Grape::ExtraValidators::MaximumLength do
     ValidationsSpec::MaximumLengthValidatorSpec::API
   end
 
-  let(:params) { { text: text } }
-  let(:text) { nil }
-  before { post "/", params }
-  subject { last_response.status }
+  describe "String value validation" do
+    let(:params) { { text: text } }
+    let(:text) { nil }
+    before { post "/text", params }
+    subject { last_response.status }
 
-  context "when the length is less than the configured maximum length" do
-    let(:text) { "1234567" }
+    context "when the length is less than the configured maximum length" do
+      let(:text) { "1234567" }
 
-    it { is_expected.to eq(204) }
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the length is equal to the configured maximum length" do
+      let(:text) { "12345678" }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the length is more than the configured maximum length" do
+      let(:text) { "123456789" }
+
+      it 'fails with corresponding message' do
+        is_expected.to eq(400)
+        expect(JSON.parse(last_response.body)["error"]).to eq("text must be up to 8 characters long")
+      end
+    end
+
+    context "when the parameter is nil" do
+      it { is_expected.to eq(204) }
+    end
   end
 
-  context "when the length is equal to the configured maximum length" do
-    let(:text) { "12345678" }
+  describe "Array value validation" do
+    let(:params) { { values: values } }
+    let(:values) { nil }
+    before { post "/array", params }
+    subject { last_response.status }
 
-    it { is_expected.to eq(204) }
+    context "when the length is less than the configured maximum length" do
+      let(:values) { [1, 2] }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the length is equal to the configured maximum length" do
+      let(:values) { [1, 2, 3] }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the length is more than the configured maximum length" do
+      let(:values) { [1, 2, 3, 4] }
+
+      it 'fails with corresponding message' do
+        is_expected.to eq(400)
+        expect(JSON.parse(last_response.body)["error"]).to eq("values must have up to 3 items")
+      end
+    end
+
+    context "when the parameter is nil" do
+      it { is_expected.to eq(204) }
+    end
   end
 
-  context "when the length is more than the configured maximum length" do
-    let(:text) { "123456789" }
-
-    it { is_expected.to eq(400) }
-  end
-
-  context "when the parameter is nil" do
-    it { is_expected.to eq(204) }
+  context "when used for a param of wrong type" do
+    let(:params) { { value: 10 } }
+    before { post "/integer", params }
+    subject { last_response.status }
+    it "fails with corresponding message" do
+      is_expected.to eq(400)
+      expect(JSON.parse(last_response.body)["error"]).to eq("value maximum length cannot be validated (wrong parameter type: Integer)")
+    end
   end
 end

--- a/spec/grape/extra_validators/minimum_length_spec.rb
+++ b/spec/grape/extra_validators/minimum_length_spec.rb
@@ -49,9 +49,10 @@ describe Grape::ExtraValidators::MinimumLength do
     context "when the length is less than the configured minimum length" do
       let(:text) { "123" }
 
-      it 'fails with corresponding message' do
+      it "fails with corresponding message" do
         is_expected.to eq(400)
-        expect(JSON.parse(last_response.body)["error"]).to eq("text must be at least 4 characters long")
+        error = JSON.parse(last_response.body)["error"]
+        expect(error).to eq("text must be at least 4 characters long")
       end
     end
 
@@ -81,9 +82,10 @@ describe Grape::ExtraValidators::MinimumLength do
     context "when the length is less than the configured minimum length" do
       let(:values) { [1, 2] }
 
-      it 'fails with corresponding message' do
+      it "fails with corresponding message" do
         is_expected.to eq(400)
-        expect(JSON.parse(last_response.body)["error"]).to eq("values must have at least 3 items")
+        error = JSON.parse(last_response.body)["error"]
+        expect(error).to eq("values must have at least 3 items")
       end
     end
 
@@ -110,7 +112,8 @@ describe Grape::ExtraValidators::MinimumLength do
     subject { last_response.status }
     it "fails with corresponding message" do
       is_expected.to eq(400)
-      expect(JSON.parse(last_response.body)["error"]).to eq("value minimum length cannot be validated (wrong parameter type: Integer)")
+      error = JSON.parse(last_response.body)["error"]
+      expect(error).to eq("value minimum length cannot be validated (wrong parameter type: Integer)")
     end
   end
 

--- a/spec/grape/extra_validators/minimum_length_spec.rb
+++ b/spec/grape/extra_validators/minimum_length_spec.rb
@@ -6,11 +6,31 @@ describe Grape::ExtraValidators::MinimumLength do
       class API < Grape::API
         default_format :json
 
-        params do
-          optional :text, type: String, minimum_length: 4
+        resource :text do
+          params do
+            optional :text, type: String, minimum_length: 4
+          end
+          post do
+            body false
+          end
         end
-        post "/" do
-          body false
+
+        resource :array do
+          params do
+            optional :values, type: Array[Integer], minimum_length: 3
+          end
+          post do
+            body false
+          end
+        end
+
+        resource :integer do
+          params do
+            optional :value, type: Integer, minimum_length: 3
+          end
+          post do
+            body false
+          end
         end
       end
     end
@@ -20,30 +40,78 @@ describe Grape::ExtraValidators::MinimumLength do
     ValidationsSpec::MinimumLengthValidatorSpec::API
   end
 
-  let(:params) { { text: text } }
-  let(:text) { nil }
-  before { post "/", params }
-  subject { last_response.status }
+  describe "String value validation" do
+    let(:params) { { text: text } }
+    let(:text) { nil }
+    before { post "/text", params }
+    subject { last_response.status }
 
-  context "when the length is less than the configured minimum length" do
-    let(:text) { "123" }
+    context "when the length is less than the configured minimum length" do
+      let(:text) { "123" }
 
-    it { is_expected.to eq(400) }
+      it 'fails with corresponding message' do
+        is_expected.to eq(400)
+        expect(JSON.parse(last_response.body)["error"]).to eq("text must be at least 4 characters long")
+      end
+    end
+
+    context "when the length is equal to the configured minimum length" do
+      let(:text) { "1234" }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the length is more than the configured minimum length" do
+      let(:text) { "12345" }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the parameter is nil" do
+      it { is_expected.to eq(204) }
+    end
   end
 
-  context "when the length is equal to the configured minimum length" do
-    let(:text) { "1234" }
+  describe "Array value validation" do
+    let(:params) { { values: values } }
+    let(:values) { nil }
+    before { post "/array", params }
+    subject { last_response.status }
 
-    it { is_expected.to eq(204) }
+    context "when the length is less than the configured minimum length" do
+      let(:values) { [1, 2] }
+
+      it 'fails with corresponding message' do
+        is_expected.to eq(400)
+        expect(JSON.parse(last_response.body)["error"]).to eq("values must have at least 3 items")
+      end
+    end
+
+    context "when the length is equal to the configured minimum length" do
+      let(:values) { [1, 2, 3] }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the length is more than the configured minimum length" do
+      let(:values) { [1, 2, 3, 4] }
+
+      it { is_expected.to eq(204) }
+    end
+
+    context "when the parameter is nil" do
+      it { is_expected.to eq(204) }
+    end
   end
 
-  context "when the length is more than the configured minimum length" do
-    let(:text) { "12345" }
-
-    it { is_expected.to eq(204) }
+  context "when used for a param of wrong type" do
+    let(:params) { { value: 10 } }
+    before { post "/integer", params }
+    subject { last_response.status }
+    it "fails with corresponding message" do
+      is_expected.to eq(400)
+      expect(JSON.parse(last_response.body)["error"]).to eq("value minimum length cannot be validated (wrong parameter type: Integer)")
+    end
   end
 
-  context "when the parameter is nil" do
-    it { is_expected.to eq(204) }
-  end
 end

--- a/spec/grape/extra_validators/version_spec.rb
+++ b/spec/grape/extra_validators/version_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Grape::ExtraValidators, type: :feature do
-  example "The version number is 2.0.0" do
-    expect(described_class::VERSION).to eq("2.0.0")
+  example "The version number is 2.1.0" do
+    expect(described_class::VERSION).to eq("2.1.0")
   end
 end


### PR DESCRIPTION
Modified length, maximum_length and minimum_length validators to work for Array params.
This can be usefult, for example, when user must select at least 3 options from the list of 10, etc.

